### PR TITLE
Rename getPermittedSubtypes() to permittedSubclasses() to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 before_install:
-  - nvm use 14
+  - nvm install 14
   - sudo apt-get install npm
   - docker build -f docker/Dockerfile -t forax/amber-record .
   - docker run -d -p 8888:8888 forax/amber-record bash travis/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk: openjdk11
+node_js:
+  - 14
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: java
 jdk: openjdk11
-node_js:
-  - 14
 
 services:
   - docker
 
 before_install:
+  - nvm use 14
   - sudo apt-get install npm
   - docker build -f docker/Dockerfile -t forax/amber-record .
   - docker run -d -p 8888:8888 forax/amber-record bash travis/script.sh

--- a/src/main/java/fr.umlv.record/fr/umlv/sealed/NonSealedExample.java
+++ b/src/main/java/fr.umlv.record/fr/umlv/sealed/NonSealedExample.java
@@ -11,7 +11,7 @@ public class NonSealedExample {
   public static void main(String[] args) {
 		I i = new A();
   	
-		var permitted = I.class.getPermittedSubtypes();
+		var permitted = I.class.permittedSubclasses();
 		System.out.println(Arrays.toString(permitted));
 	}
 }


### PR DESCRIPTION
Hi @forax,  
thanks for your help at [the core-libs-dev mailing list](https://mail.openjdk.java.net/pipermail/core-libs-dev/2021-April/076321.html). It helped me to understand the record deeper. :)

When I compare your benchmark with [mine](https://github.com/KengoTODA/records-benchmark), I found that [the latest Travis build is broken](https://travis-ci.org/github/forax/amber-record/builds/768126344#L1158):

```
src/main/java/fr.umlv.record/fr/umlv/sealed/NonSealedExample.java:14: error: cannot find symbol
		var permitted = I.class.getPermittedSubtypes();
		                       ^
  symbol:   method getPermittedSubtypes()
  location: variable class of type Class<I>
```

This is caused by an API change in Java 15; Java 15 uses [`Class#permittedSubclasses()`](https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/lang/Class.html#permittedSubclasses()) instead of `Class#getPermittedSubtypes()`.

note: I have no enough credit in Travis CI, so I haven't confirmed a successful build on Travis.
Instead, I [confirmed it on GitHub Actions](https://github.com/KengoTODA/amber-record/runs/2424415252) that uses [this workflow definision](https://github.com/KengoTODA/amber-record/blob/0bed898fc41ec1fa3bfccac71ca0e671f67b8018/.github/workflows/build.yml).

Thanks again in advance!